### PR TITLE
[API] As a user, I can search report data

### DIFF
--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -2,38 +2,12 @@ defmodule Kwtool.Crawler.KeywordResults do
   import Ecto.Query, warn: false
 
   alias Kwtool.Account.Schemas.User
-  alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
+  alias Kwtool.Crawler.Queries.KeywordResultQuery
   alias Kwtool.Repo
 
   def search(%User{id: user_id}, params \\ %{}) do
-    Keyword
-    |> join(:inner, [k], kr in KeywordResult, on: kr.keyword_id == k.id)
-    |> where([k, _kr], k.user_id == ^user_id)
-    |> maybe_search_by_keyword(params)
-    |> maybe_search_by_url(params)
-    |> maybe_search_by_ads(params)
-    |> preload(:keyword_results)
+    user_id
+    |> KeywordResultQuery.search_query(params)
     |> Repo.all()
   end
-
-  def maybe_search_by_keyword(query, %{keyword: keyword}) do
-    keyword_wildcard = "%#{keyword}%"
-
-    where(query, [k, _kr], ilike(k.phrase, ^keyword_wildcard))
-  end
-
-  def maybe_search_by_keyword(query, _), do: query
-
-  def maybe_search_by_url(query, %{url: url}) do
-    url_wildcard = "%#{url}%"
-    where(query, [_k, _kr], fragment("organic_result_urls ::text ilike ANY(array[?::text])", ^url_wildcard))
-  end
-
-  def maybe_search_by_url(query, _), do: query
-
-  def maybe_search_by_ads(query, %{min_ads: min_ads}) do
-    where(query, [_k, kr], kr.top_ads_count >= ^min_ads)
-  end
-
-  def maybe_search_by_ads(query, _), do: query
 end

--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -5,6 +5,8 @@ defmodule Kwtool.Crawler.KeywordResults do
   alias Kwtool.Crawler.Queries.KeywordResultQuery
   alias Kwtool.Repo
 
+  def search(_, params) when params == %{}, do: []
+
   def search(%User{id: user_id}, params) do
     user_id
     |> KeywordResultQuery.search_query(params)

--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -2,7 +2,7 @@ defmodule Kwtool.Crawler.KeywordResults do
   import Ecto.Query, warn: false
 
   alias Kwtool.Account.Schemas.User
-  alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
+  # alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
   alias Kwtool.Repo
 
   def search(%User{} = user, params \\ %{}) do

--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -5,15 +5,35 @@ defmodule Kwtool.Crawler.KeywordResults do
   alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
   alias Kwtool.Repo
 
-  def search(%User{} = user, params \\ %{}) do
-    search_phrase = get_in(params, ["url"])
-    url_wildcard = "%#{search_phrase}%"
-
+  def search(%User{id: user_id}, params \\ %{}) do
     Keyword
     |> join(:inner, [k], kr in KeywordResult, on: kr.keyword_id == k.id)
-    |> where([k], k.user_id == ^user.id)
-    |> where([kr], fragment("organic_result_urls ::text ilike ANY(array[?::text])", ^url_wildcard))
+    |> where([k, _kr], k.user_id == ^user_id)
+    |> maybe_search_by_keyword(params)
+    |> maybe_search_by_url(params)
+    |> maybe_search_by_ads(params)
     |> preload(:keyword_results)
     |> Repo.all()
   end
+
+  def maybe_search_by_keyword(query, %{keyword: keyword}) do
+    keyword_wildcard = "%#{keyword}%"
+
+    where(query, [k, _kr], ilike(k.phrase, ^keyword_wildcard))
+  end
+
+  def maybe_search_by_keyword(query, _), do: query
+
+  def maybe_search_by_url(query, %{url: url}) do
+    url_wildcard = "%#{url}%"
+    where(query, [_k, _kr], fragment("organic_result_urls ::text ilike ANY(array[?::text])", ^url_wildcard))
+  end
+
+  def maybe_search_by_url(query, _), do: query
+
+  def maybe_search_by_ads(query, %{min_ads: min_ads}) do
+    where(query, [_k, kr], kr.top_ads_count >= ^min_ads)
+  end
+
+  def maybe_search_by_ads(query, _), do: query
 end

--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -1,0 +1,17 @@
+defmodule Kwtool.Crawler.KeywordResults do
+  import Ecto.Query, warn: false
+
+  alias Kwtool.Account.Schemas.User
+  alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
+  alias Kwtool.Repo
+
+  def search(%User{} = user, params \\ %{}) do
+    search_phrase = get_in(params, ["query"])
+    wildcard_search = "%#{search_phrase}%"
+
+    Keyword
+    |> where([k], k.user_id == ^user.id)
+    |> where([k], ilike(k.phrase, ^wildcard_search))
+    |> Repo.all()
+  end
+end

--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -5,7 +5,7 @@ defmodule Kwtool.Crawler.KeywordResults do
   alias Kwtool.Crawler.Queries.KeywordResultQuery
   alias Kwtool.Repo
 
-  def search(%User{id: user_id}, params \\ %{}) do
+  def search(%User{id: user_id}, params) do
     user_id
     |> KeywordResultQuery.search_query(params)
     |> Repo.all()

--- a/lib/kwtool/crawler/keyword_results.ex
+++ b/lib/kwtool/crawler/keyword_results.ex
@@ -2,16 +2,18 @@ defmodule Kwtool.Crawler.KeywordResults do
   import Ecto.Query, warn: false
 
   alias Kwtool.Account.Schemas.User
-  # alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
+  alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
   alias Kwtool.Repo
 
   def search(%User{} = user, params \\ %{}) do
-    search_phrase = get_in(params, ["query"])
-    wildcard_search = "%#{search_phrase}%"
+    search_phrase = get_in(params, ["url"])
+    url_wildcard = "%#{search_phrase}%"
 
     Keyword
+    |> join(:inner, [k], kr in KeywordResult, on: kr.keyword_id == k.id)
     |> where([k], k.user_id == ^user.id)
-    |> where([k], ilike(k.phrase, ^wildcard_search))
+    |> where([kr], fragment("organic_result_urls ::text ilike ANY(array[?::text])", ^url_wildcard))
+    |> preload(:keyword_results)
     |> Repo.all()
   end
 end

--- a/lib/kwtool/crawler/queries/keyword_result_query.ex
+++ b/lib/kwtool/crawler/queries/keyword_result_query.ex
@@ -1,0 +1,41 @@
+defmodule Kwtool.Crawler.Queries.KeywordResultQuery do
+  import Ecto.Query, warn: false
+
+  alias Kwtool.Crawler.Schemas.{Keyword, KeywordResult}
+
+  def search_query(user_id, params) do
+    Keyword
+    |> join(:inner, [k], kr in KeywordResult, on: kr.keyword_id == k.id)
+    |> where([k, _kr], k.user_id == ^user_id)
+    |> maybe_search_by_keyword(params)
+    |> maybe_search_by_url(params)
+    |> maybe_search_by_ads(params)
+    |> preload(:keyword_results)
+  end
+
+  def maybe_search_by_keyword(query, %{keyword: keyword}) do
+    keyword_wildcard = "%#{keyword}%"
+
+    where(query, [k, _kr], ilike(k.phrase, ^keyword_wildcard))
+  end
+
+  def maybe_search_by_keyword(query, _), do: query
+
+  def maybe_search_by_url(query, %{url: url}) do
+    url_wildcard = "%#{url}%"
+
+    where(
+      query,
+      [_k, _kr],
+      fragment("organic_result_urls ::text ilike ANY(array[?::text])", ^url_wildcard)
+    )
+  end
+
+  def maybe_search_by_url(query, _), do: query
+
+  def maybe_search_by_ads(query, %{min_ads: min_ads}) do
+    where(query, [_k, kr], kr.all_ads_count >= ^min_ads)
+  end
+
+  def maybe_search_by_ads(query, _), do: query
+end

--- a/lib/kwtool/crawler/queries/keyword_result_query.ex
+++ b/lib/kwtool/crawler/queries/keyword_result_query.ex
@@ -5,6 +5,7 @@ defmodule Kwtool.Crawler.Queries.KeywordResultQuery do
 
   def search_query(user_id, params) do
     Keyword
+    |> distinct(true)
     |> join(:inner, [k], kr in KeywordResult, on: kr.keyword_id == k.id)
     |> where([k, _], k.user_id == ^user_id)
     |> search_by_keyword(params)

--- a/lib/kwtool/crawler/queries/keyword_result_query.ex
+++ b/lib/kwtool/crawler/queries/keyword_result_query.ex
@@ -19,8 +19,6 @@ defmodule Kwtool.Crawler.Queries.KeywordResultQuery do
     where(query, [k, _kr], ilike(k.phrase, ^keyword_wildcard))
   end
 
-  def maybe_search_by_keyword(query, _), do: query
-
   def maybe_search_by_url(query, %{url: url}) do
     url_wildcard = "%#{url}%"
 

--- a/lib/kwtool/crawler/queries/keyword_result_query.ex
+++ b/lib/kwtool/crawler/queries/keyword_result_query.ex
@@ -6,14 +6,14 @@ defmodule Kwtool.Crawler.Queries.KeywordResultQuery do
   def search_query(user_id, params) do
     Keyword
     |> join(:inner, [k], kr in KeywordResult, on: kr.keyword_id == k.id)
-    |> where([k, _kr], k.user_id == ^user_id)
-    |> maybe_search_by_keyword(params)
+    |> where([k, _], k.user_id == ^user_id)
+    |> search_by_keyword(params)
     |> maybe_search_by_url(params)
     |> maybe_search_by_ads(params)
     |> preload(:keyword_results)
   end
 
-  def maybe_search_by_keyword(query, %{keyword: keyword}) do
+  def search_by_keyword(query, %{keyword: keyword}) do
     keyword_wildcard = "%#{keyword}%"
 
     where(query, [k, _kr], ilike(k.phrase, ^keyword_wildcard))
@@ -24,7 +24,7 @@ defmodule Kwtool.Crawler.Queries.KeywordResultQuery do
 
     where(
       query,
-      [_k, _kr],
+      [_, _],
       fragment("organic_result_urls ::text ilike ANY(array[?::text])", ^url_wildcard)
     )
   end
@@ -32,7 +32,7 @@ defmodule Kwtool.Crawler.Queries.KeywordResultQuery do
   def maybe_search_by_url(query, _), do: query
 
   def maybe_search_by_ads(query, %{min_ads: min_ads}) do
-    where(query, [_k, kr], kr.all_ads_count >= ^min_ads)
+    where(query, [_, kr], kr.all_ads_count >= ^min_ads)
   end
 
   def maybe_search_by_ads(query, _), do: query

--- a/lib/kwtool_web/controllers/api/v1/search_controller.ex
+++ b/lib/kwtool_web/controllers/api/v1/search_controller.ex
@@ -2,15 +2,15 @@ defmodule KwtoolWeb.Api.V1.SearchController do
   use KwtoolWeb, :api_controller
 
   alias Kwtool.Crawler.KeywordResults
+  alias KwtoolWeb.Api.V1.SearchParams
 
   def index(conn, params) do
-    keywords =
+    # TODO, find a way to get current user
+    with {:ok, validated_params} <- ParamsValidator.validate(params, for: SearchParams),
+          keywords <- KeywordResults.search(Guardian.Plug.current_resource(conn), validated_params) do
       conn
-      |> Guardian.Plug.current_resource()
-      |> KeywordResults.search(params)
-
-    conn
-    |> put_status(:ok)
-    |> render("show.json", %{data: keywords})
+      |> put_status(:ok)
+      |> render("show.json", %{data: keywords})
+    end
   end
 end

--- a/lib/kwtool_web/controllers/api/v1/search_controller.ex
+++ b/lib/kwtool_web/controllers/api/v1/search_controller.ex
@@ -1,0 +1,16 @@
+defmodule KwtoolWeb.Api.V1.SearchController do
+  use KwtoolWeb, :api_controller
+
+  alias Kwtool.Crawler.KeywordResults
+
+  def index(conn, params) do
+    keywords =
+      conn
+      |> Guardian.Plug.current_resource()
+      |> KeywordResults.search(params)
+
+    conn
+    |> put_status(:ok)
+    |> render("show.json", %{data: keywords})
+  end
+end

--- a/lib/kwtool_web/controllers/api/v1/search_controller.ex
+++ b/lib/kwtool_web/controllers/api/v1/search_controller.ex
@@ -5,9 +5,8 @@ defmodule KwtoolWeb.Api.V1.SearchController do
   alias KwtoolWeb.Api.V1.SearchParams
 
   def index(conn, params) do
-    # TODO, find a way to get current user
     with {:ok, validated_params} <- ParamsValidator.validate(params, for: SearchParams),
-          keywords <- KeywordResults.search(Guardian.Plug.current_resource(conn), validated_params) do
+         keywords <- KeywordResults.search(Guardian.Plug.current_resource(conn), validated_params) do
       conn
       |> put_status(:ok)
       |> render("show.json", %{data: keywords})

--- a/lib/kwtool_web/controllers/api/v1/search_controller.ex
+++ b/lib/kwtool_web/controllers/api/v1/search_controller.ex
@@ -6,7 +6,7 @@ defmodule KwtoolWeb.Api.V1.SearchController do
 
   def index(conn, params) do
     with {:ok, validated_params} <- ParamsValidator.validate(params, for: SearchParams),
-         keywords <- KeywordResults.search(Guardian.Plug.current_resource(conn), validated_params) do
+         keywords <- KeywordResults.search(conn.assigns.current_user, validated_params) do
       conn
       |> put_status(:ok)
       |> render("show.json", %{data: keywords})

--- a/lib/kwtool_web/params/api/v1/search_params.ex
+++ b/lib/kwtool_web/params/api/v1/search_params.ex
@@ -10,5 +10,6 @@ defmodule KwtoolWeb.Api.V1.SearchParams do
   def changeset(data \\ %__MODULE__{}, params) do
     data
     |> cast(params, [:url, :min_ads, :keyword])
+    |> validate_required([:keyword])
   end
 end

--- a/lib/kwtool_web/params/api/v1/search_params.ex
+++ b/lib/kwtool_web/params/api/v1/search_params.ex
@@ -1,0 +1,14 @@
+defmodule KwtoolWeb.Api.V1.SearchParams do
+  use KwtoolWeb.Params
+
+  embedded_schema do
+    field :url, :string
+    field :min_ads, :integer
+    field :keyword, :string
+  end
+
+  def changeset(data \\ %__MODULE__{}, params) do
+    data
+    |> cast(params, [:url, :min_ads, :keyword])
+  end
+end

--- a/lib/kwtool_web/router.ex
+++ b/lib/kwtool_web/router.ex
@@ -53,6 +53,8 @@ defmodule KwtoolWeb.Router do
     post "/upload", UploadController, :create
 
     resources "/keywords", KeywordController, only: [:index, :show]
+
+    get "/search", SearchController, :index
   end
 
   scope "/", KwtoolWeb do

--- a/lib/kwtool_web/views/api/v1/search_view.ex
+++ b/lib/kwtool_web/views/api/v1/search_view.ex
@@ -1,0 +1,12 @@
+defmodule KwtoolWeb.Api.V1.SearchView do
+  use JSONAPI.View, type: "keywords"
+
+  def fields do
+    [
+      :phrase,
+      :status,
+      :inserted_at,
+      :updated_at
+    ]
+  end
+end

--- a/lib/kwtool_web/views/api/v1/search_view.ex
+++ b/lib/kwtool_web/views/api/v1/search_view.ex
@@ -9,4 +9,10 @@ defmodule KwtoolWeb.Api.V1.SearchView do
       :updated_at
     ]
   end
+
+  def relationships do
+    [
+      keyword_results: {KwtoolWeb.Api.V1.KeywordResultView, :include}
+    ]
+  end
 end

--- a/test/kwtool/crawler/keyword_results_test.exs
+++ b/test/kwtool/crawler/keyword_results_test.exs
@@ -12,20 +12,23 @@ defmodule Kwtool.KeywordResultsTest do
       [keyword_result] = KeywordResults.search(user, %{keyword: "coffee"})
 
       assert Enum.count(keyword_result.keyword_results) == 1
-      assert keyword.id == keyword_result.id
-      assert keyword.phrase == "coffee"
+      assert keyword_result.id == keyword.id
+      assert keyword_result.keyword.phrase == "coffee"
     end
 
-    test "given an existing keyword with Url, returns the matching keyword and url" do
+    test "given an existing keyword with url, returns the matching keyword and url" do
       user = insert(:user)
-      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
-      insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://star-coffee.com"])
+      keyword_1 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword_1, organic_result_urls: ["https://star-coffee.com"])
+
+      keyword_2 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword_2, organic_result_urls: ["https://starbuck.com"])
 
       [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", url: "star-coffee.com"})
 
       assert Enum.count(keyword_result.keyword_results) == 1
-      assert keyword.id == keyword_result.id
-      assert keyword.phrase == "coffee"
+      assert keyword_1.id == keyword_result.id
+      assert keyword_1.phrase == "coffee"
     end
 
     test "given an existing keyword has multiple crawl results, returns the matching keyword and url" do
@@ -43,13 +46,16 @@ defmodule Kwtool.KeywordResultsTest do
 
     test "given an existing keyword with ads count, returns the matching keyword and ads count" do
       user = insert(:user)
-      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
-      insert(:keyword_result, keyword: keyword, all_ads_count: 13)
+      keyword_1 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword_1, all_ads_count: 13)
+
+      keyword_2 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword_2, all_ads_count: 10)
 
       [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", min_ads: 12})
 
-      assert keyword.id == keyword_result.id
-      assert keyword.phrase == "coffee"
+      assert keyword_1.id == keyword_result.id
+      assert keyword_1.phrase == "coffee"
     end
 
     test "given an empty param, returns an empty list" do

--- a/test/kwtool/crawler/keyword_results_test.exs
+++ b/test/kwtool/crawler/keyword_results_test.exs
@@ -37,7 +37,7 @@ defmodule Kwtool.KeywordResultsTest do
       assert keyword.phrase == "coffee"
     end
 
-    test "given a keyword does NOT exist, returns the matching keyword result" do
+    test "given a keyword does NOT exist, returns an empty list" do
       user = insert(:user)
       keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
       insert(:keyword_result, keyword: keyword, all_ads_count: 12)

--- a/test/kwtool/crawler/keyword_results_test.exs
+++ b/test/kwtool/crawler/keyword_results_test.exs
@@ -9,26 +9,29 @@ defmodule Kwtool.KeywordResultsTest do
       keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
       insert(:keyword_result, keyword: keyword)
 
-      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee"})
+      [expected_keyword] = KeywordResults.search(user, %{keyword: "coffee"})
 
-      assert Enum.count(keyword_result.keyword_results) == 1
-      assert keyword_result.id == keyword.id
-      assert keyword_result.keyword.phrase == "coffee"
+      assert Enum.count(expected_keyword.keyword_results) == 1
+      assert expected_keyword.id == keyword.id
+      assert expected_keyword.phrase == "coffee"
     end
 
     test "given an existing keyword with url, returns the matching keyword and url" do
       user = insert(:user)
-      keyword_1 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
-      insert(:keyword_result, keyword: keyword_1, organic_result_urls: ["https://star-coffee.com"])
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://star-coffee.com"])
 
-      keyword_2 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
-      insert(:keyword_result, keyword: keyword_2, organic_result_urls: ["https://starbuck.com"])
+      not_included_keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
 
-      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", url: "star-coffee.com"})
+      insert(:keyword_result,
+        keyword: not_included_keyword,
+        organic_result_urls: ["https://starbuck.com"]
+      )
 
-      assert Enum.count(keyword_result.keyword_results) == 1
-      assert keyword_1.id == keyword_result.id
-      assert keyword_1.phrase == "coffee"
+      [expected_keyword] = KeywordResults.search(user, %{keyword: "coffee", url: "star-coffee.com"})
+
+      assert expected_keyword.id == keyword.id
+      assert expected_keyword.phrase == "coffee"
     end
 
     test "given an existing keyword has multiple crawl results, returns the matching keyword and url" do
@@ -37,25 +40,25 @@ defmodule Kwtool.KeywordResultsTest do
       insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://star-coffee.com"])
       insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://black-coffee.com"])
 
-      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", url: "coffee"})
+      [expected_keyword] = KeywordResults.search(user, %{keyword: "coffee", url: "coffee"})
 
-      assert Enum.count(keyword_result.keyword_results) == 2
-      assert keyword.id == keyword_result.id
-      assert keyword.phrase == "coffee"
+      assert Enum.count(expected_keyword.keyword_results) == 2
+      assert expected_keyword.id == keyword.id
+      assert expected_keyword.phrase == "coffee"
     end
 
     test "given an existing keyword with ads count, returns the matching keyword and ads count" do
       user = insert(:user)
-      keyword_1 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
-      insert(:keyword_result, keyword: keyword_1, all_ads_count: 13)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword, all_ads_count: 13)
 
-      keyword_2 = insert(:keyword, phrase: "coffee", status: "finished", user: user)
-      insert(:keyword_result, keyword: keyword_2, all_ads_count: 10)
+      not_included_keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: not_included_keyword, all_ads_count: 10)
 
-      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", min_ads: 12})
+      [expected_keyword] = KeywordResults.search(user, %{keyword: "coffee", min_ads: 12})
 
-      assert keyword_1.id == keyword_result.id
-      assert keyword_1.phrase == "coffee"
+      assert expected_keyword.id == keyword.id
+      assert expected_keyword.phrase == "coffee"
     end
 
     test "given an empty param, returns an empty list" do

--- a/test/kwtool/crawler/keyword_results_test.exs
+++ b/test/kwtool/crawler/keyword_results_test.exs
@@ -11,6 +11,7 @@ defmodule Kwtool.KeywordResultsTest do
 
       [keyword_result] = KeywordResults.search(user, %{keyword: "coffee"})
 
+      assert Enum.count(keyword_result.keyword_results) == 1
       assert keyword.id == keyword_result.id
       assert keyword.phrase == "coffee"
     end
@@ -22,6 +23,20 @@ defmodule Kwtool.KeywordResultsTest do
 
       [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", url: "star-coffee.com"})
 
+      assert Enum.count(keyword_result.keyword_results) == 1
+      assert keyword.id == keyword_result.id
+      assert keyword.phrase == "coffee"
+    end
+
+    test "given an existing keyword has multiple crawl results, returns the matching keyword and url" do
+      user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://star-coffee.com"])
+      insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://black-coffee.com"])
+
+      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", url: "coffee"})
+
+      assert Enum.count(keyword_result.keyword_results) == 2
       assert keyword.id == keyword_result.id
       assert keyword.phrase == "coffee"
     end
@@ -37,20 +52,18 @@ defmodule Kwtool.KeywordResultsTest do
       assert keyword.phrase == "coffee"
     end
 
+    test "given an empty param, returns an empty list" do
+      user = insert(:user)
+
+      assert KeywordResults.search(user, %{}) == []
+    end
+
     test "given a keyword does NOT exist, returns an empty list" do
       user = insert(:user)
       keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
       insert(:keyword_result, keyword: keyword, all_ads_count: 12)
 
       assert KeywordResults.search(user, %{keyword: "latte"}) == []
-    end
-
-    test "given an empty params, returns the matching keyword result" do
-      user = insert(:user)
-
-      assert_raise FunctionClauseError, fn ->
-        KeywordResults.search(user, %{}) == []
-      end
     end
   end
 end

--- a/test/kwtool/crawler/keyword_results_test.exs
+++ b/test/kwtool/crawler/keyword_results_test.exs
@@ -1,0 +1,56 @@
+defmodule Kwtool.KeywordResultsTest do
+  use Kwtool.DataCase, async: true
+
+  alias Kwtool.Crawler.KeywordResults
+
+  describe "search/2" do
+    test "given an existing keyword, returns the matching keyword result" do
+      user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword)
+
+      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee"})
+
+      assert keyword.id == keyword_result.id
+      assert keyword.phrase == "coffee"
+    end
+
+    test "given an existing keyword with Url, returns the matching keyword and url" do
+      user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword, organic_result_urls: ["https://star-coffee.com"])
+
+      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", url: "star-coffee.com"})
+
+      assert keyword.id == keyword_result.id
+      assert keyword.phrase == "coffee"
+    end
+
+    test "given an existing keyword with ads count, returns the matching keyword and ads count" do
+      user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword, all_ads_count: 13)
+
+      [keyword_result] = KeywordResults.search(user, %{keyword: "coffee", min_ads: 12})
+
+      assert keyword.id == keyword_result.id
+      assert keyword.phrase == "coffee"
+    end
+
+    test "given a keyword does NOT exist, returns the matching keyword result" do
+      user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: user)
+      insert(:keyword_result, keyword: keyword, all_ads_count: 12)
+
+      assert KeywordResults.search(user, %{keyword: "latte"}) == []
+    end
+
+    test "given an empty params, returns the matching keyword result" do
+      user = insert(:user)
+
+      assert_raise FunctionClauseError, fn ->
+        KeywordResults.search(user, %{}) == []
+      end
+    end
+  end
+end

--- a/test/kwtool/crawler/schemas/keyword_result_test.exs
+++ b/test/kwtool/crawler/schemas/keyword_result_test.exs
@@ -16,9 +16,9 @@ defmodule Kwtool.Crawler.Schemas.KeywordResultTest do
                all_ads_count: 2,
                all_links_count: 2,
                organic_result_count: 2,
-               organic_result_urls: ["https://google.com", "https://example.com"],
+               organic_result_urls: ["https://company-a.com", "https://company-b.com"],
                top_ads_count: 2,
-               top_ads_urls: ["https://google.com", "https://example.com"],
+               top_ads_urls: ["https://ads-product-a.com", "https://ads-product-b.com"],
                keyword_id: keyword.id,
                html: "<html><head><title>crawler</title></head><body>News sites</body></html>"
              }

--- a/test/kwtool_web/controllers/api/v1/keyword_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/keyword_controller_test.exs
@@ -91,9 +91,9 @@ defmodule KwtoolWeb.Api.V1.KeywordControllerTest do
                      "all_ads_count" => 2,
                      "all_links_count" => 2,
                      "organic_result_count" => 2,
-                     "organic_result_urls" => ["https://google.com", "https://example.com"],
+                     "organic_result_urls" => ["https://company-a.com", "https://company-b.com"],
                      "top_ads_count" => 2,
-                     "top_ads_urls" => ["https://google.com", "https://example.com"]
+                     "top_ads_urls" => ["https://ads-product-a.com", "https://ads-product-b.com"]
                    },
                    "id" => _,
                    "relationships" => %{},

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -50,7 +50,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
              } = json_response(conn, 200)
     end
 
-    test "given search with keyword, url, and min ads count params, returns keyword with matching conditions",
+    test "given search with keyword, url, and min ads count params, returns keyword that matching given filters",
          %{conn: conn} do
       created_user = insert(:user)
       keyword = insert(:keyword, phrase: "coffee", status: "finished", user: created_user)

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -4,7 +4,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
   import KwtoolWeb.Support.ConnHelper
 
   describe "get index/2" do
-    test "given search with keyword param, returns a list of matching keyword", %{
+    test "given search with keyword param, returns a list of matching keywords", %{
       conn: conn
     } do
       created_user = insert(:user)
@@ -50,7 +50,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
              } = json_response(conn, 200)
     end
 
-    test "given search with keyword, url, and min ads count params, returns keyword that matching given filters",
+    test "given search with keyword, url, and min ads count params, returns keywords that matching given filters",
          %{conn: conn} do
       created_user = insert(:user)
       keyword = insert(:keyword, phrase: "coffee", status: "finished", user: created_user)
@@ -181,7 +181,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
         |> with_signed_in_user(created_user)
         |> get(Routes.api_search_path(conn, :index, %{"keyword" => "something else"}))
 
-      assert %{"data" => [], "included" => []} = json_response(conn, 200)
+      assert json_response(conn, 200) == %{"data" => [], "included" => []}
     end
 
     test "given missing keyword in search params, returns an error", %{conn: conn} do

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -192,7 +192,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
         |> with_signed_in_user(created_user)
         |> get(Routes.api_search_path(conn, :index))
 
-      assert %{
+      assert json_response(conn, 422) == %{
                "errors" => [
                  %{
                    "code" => "validation_error",
@@ -200,13 +200,13 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
                    "message" => "Keyword can't be blank"
                  }
                ]
-             } = json_response(conn, 422)
+             }
     end
 
     test "given unauthorized request, returns unauthorized response", %{conn: conn} do
       conn = get(conn, Routes.api_search_path(conn, :index))
 
-      assert %{
+      assert json_response(conn, 401) == %{
                "errors" => [
                  %{
                    "code" => "unauthorized",
@@ -214,7 +214,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
                    "message" => "Unauthorized"
                  }
                ]
-             } = json_response(conn, 401)
+             }
     end
   end
 end

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -4,7 +4,9 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
   import KwtoolWeb.Support.ConnHelper
 
   describe "get index/2" do
-    test "given user has keyword, returns a list of keyword", %{conn: conn} do
+    test "given search with keyword param, returns a list of matching keyword", %{
+      conn: conn
+    } do
       created_user = insert(:user)
       keyword = insert(:keyword, phrase: "cheap flights", status: "finished", user: created_user)
       insert(:keyword_result, keyword: keyword)
@@ -12,7 +14,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
       conn =
         conn
         |> with_signed_in_user(created_user)
-        |> get(Routes.api_search_path(conn, :index, %{"url" => "google.com"}))
+        |> get(Routes.api_search_path(conn, :index, %{"keyword" => "cheap flights"}))
 
       assert %{
                "data" => [
@@ -36,9 +38,9 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
                      "all_ads_count" => 2,
                      "all_links_count" => 2,
                      "organic_result_count" => 2,
-                     "organic_result_urls" => ["https://google.com", "https://example.com"],
+                     "organic_result_urls" => ["https://company-a.com", "https://company-b.com"],
                      "top_ads_count" => 2,
-                     "top_ads_urls" => ["https://google.com", "https://example.com"]
+                     "top_ads_urls" => ["https://ads-product-a.com", "https://ads-product-b.com"]
                    },
                    "id" => _,
                    "relationships" => %{},
@@ -48,7 +50,72 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
              } = json_response(conn, 200)
     end
 
-    test "given user does NOT have any keyword, returns an empty list", %{conn: conn} do
+    test "given search with keyword, url, and min ads count params, returns keyword with matching conditions",
+         %{conn: conn} do
+      created_user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: created_user)
+      insert(:keyword_result, keyword: keyword, all_ads_count: 12)
+
+      conn =
+        conn
+        |> with_signed_in_user(created_user)
+        |> get(
+          Routes.api_search_path(conn, :index, %{
+            "keyword" => "coffee",
+            "url" => "company-a.com",
+            "min_ads" => 10
+          })
+        )
+
+      assert %{
+               "data" => [
+                 %{
+                   "attributes" => %{
+                     "inserted_at" => _,
+                     "phrase" => "coffee",
+                     "status" => "finished",
+                     "updated_at" => _
+                   },
+                   "id" => _,
+                   "relationships" => %{
+                     "keyword_results" => %{"data" => [%{"id" => _, "type" => "keyword_result"}]}
+                   },
+                   "type" => "keywords"
+                 }
+               ],
+               "included" => [
+                 %{
+                   "attributes" => %{
+                     "all_ads_count" => 12,
+                     "all_links_count" => 2,
+                     "organic_result_count" => 2,
+                     "organic_result_urls" => ["https://company-a.com", "https://company-b.com"],
+                     "top_ads_count" => 2,
+                     "top_ads_urls" => ["https://ads-product-a.com", "https://ads-product-b.com"]
+                   },
+                   "id" => _,
+                   "relationships" => %{},
+                   "type" => "keyword_result"
+                 }
+               ]
+             } = json_response(conn, 200)
+    end
+
+    test "given search with keyword does not exist, returns an empty result",
+         %{conn: conn} do
+      created_user = insert(:user)
+      keyword = insert(:keyword, phrase: "coffee", status: "finished", user: created_user)
+      insert(:keyword_result, keyword: keyword, all_ads_count: 12)
+
+      conn =
+        conn
+        |> with_signed_in_user(created_user)
+        |> get(Routes.api_search_path(conn, :index, %{"keyword" => "something else"}))
+
+      assert %{"data" => [], "included" => []} = json_response(conn, 200)
+    end
+
+    test "given missing keyword in search params, returns an error", %{conn: conn} do
       created_user = insert(:user)
 
       conn =
@@ -56,7 +123,15 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
         |> with_signed_in_user(created_user)
         |> get(Routes.api_search_path(conn, :index))
 
-      assert %{"data" => [], "included" => []} = json_response(conn, 200)
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "validation_error",
+                   "detail" => %{"keyword" => ["can't be blank"]},
+                   "message" => "Keyword can't be blank"
+                 }
+               ]
+             } = json_response(conn, 422)
     end
 
     test "given unauthorized request, returns unauthorized response", %{conn: conn} do

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -1,0 +1,59 @@
+defmodule KwtoolWeb.Api.V1.SearchControllerTest do
+  use KwtoolWeb.ConnCase, async: true
+
+  import KwtoolWeb.Support.ConnHelper
+
+  describe "get index/2" do
+    test "given user has keyword, returns a list of keyword", %{conn: conn} do
+      created_user = insert(:user)
+      insert(:keyword, phrase: "cheap flights", status: "finished", user: created_user)
+
+      conn =
+        conn
+        |> with_signed_in_user(created_user)
+        |> get(Routes.api_search_path(conn, :index))
+
+      assert %{
+               "data" => [
+                 %{
+                   "attributes" => %{
+                     "inserted_at" => _,
+                     "phrase" => "cheap flights",
+                     "status" => "finished",
+                     "updated_at" => _
+                   },
+                   "id" => _,
+                   "relationships" => %{},
+                   "type" => "keywords"
+                 }
+               ],
+               "included" => []
+             } = json_response(conn, 200)
+    end
+
+    test "given user does NOT have any keyword, returns an empty list", %{conn: conn} do
+      created_user = insert(:user)
+
+      conn =
+        conn
+        |> with_signed_in_user(created_user)
+        |> get(Routes.api_search_path(conn, :index))
+
+      assert %{"data" => [], "included" => []} = json_response(conn, 200)
+    end
+
+    test "given unauthorized request, returns unauthorized response", %{conn: conn} do
+      conn = get(conn, Routes.api_search_path(conn, :index))
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unauthorized",
+                   "detail" => %{},
+                   "message" => "Unauthorized"
+                 }
+               ]
+             } = json_response(conn, 401)
+    end
+  end
+end

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -63,6 +63,17 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
         ]
       )
 
+      not_included_keyword =
+        insert(:keyword, phrase: "cafe", status: "finished", user: created_user)
+
+      insert(:keyword_result,
+        keyword: not_included_keyword,
+        all_ads_count: 9,
+        organic_result_urls: [
+          "https://company-a.com"
+        ]
+      )
+
       conn =
         conn
         |> with_signed_in_user(created_user)

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -50,11 +50,18 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
              } = json_response(conn, 200)
     end
 
-    test "given search with keyword, url, and min ads count params, returns keywords that matching given filters",
+    test "given search with keyword, url in organic_result_urls, and min ads count params, returns keywords that matching given filters",
          %{conn: conn} do
       created_user = insert(:user)
       keyword = insert(:keyword, phrase: "coffee", status: "finished", user: created_user)
-      insert(:keyword_result, keyword: keyword, all_ads_count: 12)
+
+      insert(:keyword_result,
+        keyword: keyword,
+        all_ads_count: 12,
+        organic_result_urls: [
+          "https://company-a.com"
+        ]
+      )
 
       conn =
         conn
@@ -89,7 +96,7 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
                      "all_ads_count" => 12,
                      "all_links_count" => 2,
                      "organic_result_count" => 2,
-                     "organic_result_urls" => ["https://company-a.com", "https://company-b.com"],
+                     "organic_result_urls" => ["https://company-a.com"],
                      "top_ads_count" => 2,
                      "top_ads_urls" => ["https://ads-product-a.com", "https://ads-product-b.com"]
                    },

--- a/test/kwtool_web/controllers/api/v1/search_controller_test.exs
+++ b/test/kwtool_web/controllers/api/v1/search_controller_test.exs
@@ -6,12 +6,13 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
   describe "get index/2" do
     test "given user has keyword, returns a list of keyword", %{conn: conn} do
       created_user = insert(:user)
-      insert(:keyword, phrase: "cheap flights", status: "finished", user: created_user)
+      keyword = insert(:keyword, phrase: "cheap flights", status: "finished", user: created_user)
+      insert(:keyword_result, keyword: keyword)
 
       conn =
         conn
         |> with_signed_in_user(created_user)
-        |> get(Routes.api_search_path(conn, :index))
+        |> get(Routes.api_search_path(conn, :index, %{"url" => "google.com"}))
 
       assert %{
                "data" => [
@@ -23,11 +24,27 @@ defmodule KwtoolWeb.Api.V1.SearchControllerTest do
                      "updated_at" => _
                    },
                    "id" => _,
-                   "relationships" => %{},
+                   "relationships" => %{
+                     "keyword_results" => %{"data" => [%{"id" => _, "type" => "keyword_result"}]}
+                   },
                    "type" => "keywords"
                  }
                ],
-               "included" => []
+               "included" => [
+                 %{
+                   "attributes" => %{
+                     "all_ads_count" => 2,
+                     "all_links_count" => 2,
+                     "organic_result_count" => 2,
+                     "organic_result_urls" => ["https://google.com", "https://example.com"],
+                     "top_ads_count" => 2,
+                     "top_ads_urls" => ["https://google.com", "https://example.com"]
+                   },
+                   "id" => _,
+                   "relationships" => %{},
+                   "type" => "keyword_result"
+                 }
+               ]
              } = json_response(conn, 200)
     end
 

--- a/test/kwtool_web/params/api/v1/search_params_test.exs
+++ b/test/kwtool_web/params/api/v1/search_params_test.exs
@@ -1,4 +1,4 @@
-defmodule KwtoolWeb.SearchParamsTest do
+defmodule KwtoolWeb.Api.V1.SearchParamsTest do
   use Kwtool.DataCase, async: true
 
   alias KwtoolWeb.Api.V1.SearchParams

--- a/test/kwtool_web/params/search_params_test.exs
+++ b/test/kwtool_web/params/search_params_test.exs
@@ -22,7 +22,7 @@ defmodule KwtoolWeb.SearchParamsTest do
              }
     end
 
-    test "given invalid params, returns a valid changeset" do
+    test "given invalid params, returns an invalid changeset" do
       changeset = SearchParams.changeset(%{})
 
       assert changeset.valid? == false

--- a/test/kwtool_web/params/search_params_test.exs
+++ b/test/kwtool_web/params/search_params_test.exs
@@ -1,0 +1,32 @@
+defmodule KwtoolWeb.SearchParamsTest do
+  use Kwtool.DataCase, async: true
+
+  alias KwtoolWeb.Api.V1.SearchParams
+
+  describe "changeset/2" do
+    test "given valid params, returns a valid changeset" do
+      params = %{
+        url: "kwtool.co",
+        min_ads: 1,
+        keyword: "iPhone"
+      }
+
+      changeset = SearchParams.changeset(params)
+
+      assert changeset.valid? == true
+
+      assert changeset.changes == %{
+               url: "kwtool.co",
+               min_ads: 1,
+               keyword: "iPhone"
+             }
+    end
+
+    test "given invalid params, returns a valid changeset" do
+      changeset = SearchParams.changeset(%{})
+
+      assert changeset.valid? == false
+      assert errors_on(changeset) == %{keyword: ["can't be blank"]}
+    end
+  end
+end

--- a/test/support/factories/keyword_result_factory.ex
+++ b/test/support/factories/keyword_result_factory.ex
@@ -4,10 +4,10 @@ defmodule Kwtool.KeywordResultFactory do
       def keyword_result_factory do
         %Kwtool.Crawler.Schemas.KeywordResult{
           top_ads_count: 2,
-          top_ads_urls: ["https://google.com", "https://example.com"],
+          top_ads_urls: ["https://ads-product-a.com", "https://ads-product-b.com"],
           all_ads_count: 2,
           organic_result_count: 2,
-          organic_result_urls: ["https://google.com", "https://example.com"],
+          organic_result_urls: ["https://company-a.com", "https://company-b.com"],
           all_links_count: 2,
           html: "<html><head><title>crawler</title></head><body>News sites</body></html>",
           keyword: build(:keyword)


### PR DESCRIPTION
Issue: https://github.com/byhbt/kwtool/issues/36

## What happened

As a user, I can search on the API.

For example: Search `cheap flights` keyword which has the `URL` containing `emirates` word in the result and has `min_ads > 5`.

- The `keyword` will be looked up in field `phrase` on `keywords` table. This is required field.
- The `url` will be looked up in field `organic_result_urls`.
- The `min_ads` will be compared with `all_ads_count`.

![image](https://user-images.githubusercontent.com/948856/160531177-f2cf6e6f-93c8-4498-a900-d6b7705bcb4d.png)

![image](https://user-images.githubusercontent.com/948856/160524602-bf89bf51-f6da-4c79-8542-5d0af1e5d02c.png)

## Insight

n/a
 
## Proof Of Work

The tests should pass. 
